### PR TITLE
Fix folder /var/lock/subsys does not exists in centos 6

### DIFF
--- a/daemon_linux_systemv.go
+++ b/daemon_linux_systemv.go
@@ -234,6 +234,8 @@ lockfile="/var/lock/subsys/$proc"
 stdoutlog="/var/log/$proc.log"
 stderrlog="/var/log/$proc.err"
 
+mkdir -p /var/lock/subsys
+
 [ -e /etc/sysconfig/$proc ] && . /etc/sysconfig/$proc
 
 start() {


### PR DESCRIPTION
Hi Igor,

I had already fixed in develop branch. 
Thank you