### PR TITLE
Fix wrong stdout and stderr redirection

### DIFF
--- a/daemon_linux_systemv.go
+++ b/daemon_linux_systemv.go
@@ -244,7 +244,7 @@ start() {
     if ! [ -f $pidfile ]; then
         printf "Starting $servname:\t"
         echo "$(date)" >> $stdoutlog
-        $exec >> $stderrlog 2>> $stdoutlog &
+        $exec >> $stdoutlog 2>> $stderrlog &
         echo $! > $pidfile
         touch $lockfile
         success


### PR DESCRIPTION
I think the order of output redirection in systemV is wrong. When I try to build it in my Mac, everything is working fine but when i try to build it in my centos machine, my stderr output goes to appname.log, and the other way around.