### PR TITLE
Use a correct process name when start service from /etc/rc3.d/S87xxxx

### DIFF
--- a/daemon_linux_systemv.go
+++ b/daemon_linux_systemv.go
@@ -228,7 +228,7 @@ fi
 exec="{{.Path}}"
 servname="{{.Description}}"
 
-proc=$(basename $0)
+proc=$(basename $exec)
 pidfile="/var/run/$proc.pid"
 lockfile="/var/lock/subsys/$proc"
 stdoutlog="/var/log/$proc.log"


### PR DESCRIPTION
`$proc` in `/etc/init.d/xxxxxx` is set different value by start method, because current template generate `$proc` from `$0`.

```
# echo `basename /etc/init.d/xxxxxxxx`
xxxxxxxx
# echo `basename /etc/rc3.d/S87xxxxxxxx`
S87xxxxxxxx
```

As a result of above difference, `/var/run/xxxx.pid` is confused.

### Reproduce methods
1. Start service from `/etc/rc3.d/S87xxxxxxxx` while launch instance.
2. SSH login to it instance. and execute follow command.
```
# service xxxxxxxx status
xxxxxxxx is stopped
# ps aux | grep xxxxxxxx
root      1753  0.0  0.2 179124  5192 pts/1    Sl   11:41   0:00 /opt/xxxxxxxx
root      1770  0.0  0.0 103240   868 pts/1    R+   11:49   0:00 grep xxxxxxxx
```
