### PR TITLE
Stub execPath method to compile for windows

### DIFF
--- a/daemon_windows.go
+++ b/daemon_windows.go
@@ -53,3 +53,8 @@ func (windows *windowsRecord) Status() (string, error) {
 
 	return "Status could not defined", errors.New("windows daemon is not supported")
 }
+
+// Get executable path
+func execPath() (string, error) {
+	return "", errors.New("windows daemon is not supported")
+}


### PR DESCRIPTION
Suppress compile error when execute following command

```
$ GOOS=windows go build
# github.com/takama/daemon
./helper.go:21: undefined: execPath
./helper.go:25: undefined: execPath
```