### PR TITLE
Add optional arguments to start command for systemd and upstart

### DIFF
--- a/daemon_linux_systemd.go
+++ b/daemon_linux_systemd.go
@@ -200,7 +200,7 @@ After={{.Dependencies}}
 [Service]
 PIDFile=/var/run/{{.Name}}.pid
 ExecStartPre=/bin/rm -f /var/run/{{.Name}}.pid
-ExecStart={{.Path}}
+ExecStart={{.Path}} {{.Args}}
 Restart=on-abort
 
 [Install]

--- a/daemon_linux_upstart.go
+++ b/daemon_linux_upstart.go
@@ -188,5 +188,5 @@ stop on runlevel [016]
 
 #kill timeout 5
 
-exec {{.Path}} >> /var/log/{{.Name}}.log 2>> /var/log/{{.Name}}.err
+exec {{.Path}} {{.Args}} >> /var/log/{{.Name}}.log 2>> /var/log/{{.Name}}.err
 `


### PR DESCRIPTION
This patch resolves the issue for systemd and upstart. It doesn't fix the windows service. 
