### PR TITLE
change restart property on linux, systemd

### DIFF
--- a/daemon_linux_systemd.go
+++ b/daemon_linux_systemd.go
@@ -201,7 +201,7 @@ After={{.Dependencies}}
 PIDFile=/var/run/{{.Name}}.pid
 ExecStartPre=/bin/rm -f /var/run/{{.Name}}.pid
 ExecStart={{.Path}} {{.Args}}
-Restart=on-abort
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#54 

changed property value on linux sysytemd.
- before

```
Restart=on-abort
```

- after

```
Restart=on-failure
```

this will cause the process restarted on more failure type exit.
Currently, the process will be not restarted on Panic.

(details: https://www.freedesktop.org/software/systemd/man/systemd.service.html ,see Table 1)

> Setting this to on-failure is the recommended choice for long-running services, in order to increase reliability by attempting automatic recovery from errors. For services that shall be able to terminate on their own choice (and avoid immediate restarting), on-abnormal is an alternative choice.