### PR TITLE
Use arguments in dameon_windows.go install method

### DIFF
--- a/daemon_windows.go
+++ b/daemon_windows.go
@@ -39,7 +39,10 @@ func (windows *windowsRecord) Install(args ...string) (string, error) {
 		return installAction + failed, err
 	}
 
-	cmd := exec.Command("nssm.exe", "install", windows.name, execp)
+	cmdArgs := []string{"install", windows.name, execp}
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.Command("nssm.exe", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		if len(out) > 0 {


### PR DESCRIPTION
This fork fix the install method for Windows that didn't use the args parameters in the method.
It just creates the list with the original parameters and append the arguments into that list.