### PR TITLE
Add recovery action for windows service

### DIFF
--- a/daemon_windows.go
+++ b/daemon_windows.go
@@ -65,6 +65,30 @@ func (windows *windowsRecord) Install(args ...string) (string, error) {
 	}
 	defer s.Close()
 
+	// set recovery action for service
+	// restart after 5 seconds for the first 3 times
+	// restart after 1 minute, otherwise
+	r := []mgr.RecoveryAction{
+		mgr.RecoveryAction{
+			Type:  mgr.ServiceRestart,
+			Delay: 5000 * time.Millisecond,
+		},
+		mgr.RecoveryAction{
+			Type:  mgr.ServiceRestart,
+			Delay: 5000 * time.Millisecond,
+		},
+		mgr.RecoveryAction{
+			Type:  mgr.ServiceRestart,
+			Delay: 5000 * time.Millisecond,
+		},
+		mgr.RecoveryAction{
+			Type:  mgr.ServiceRestart,
+			Delay: 60000 * time.Millisecond,
+		},
+	}
+	// set reset period as a day
+	s.SetRecoveryActions(r, uint32(86400))
+
 	return installAction + " completed.", nil
 }
 


### PR DESCRIPTION
`golang.org/x/sys/windows/svc/mgr` has implemented recovery action and related method.

This PR set default recovery action for windows service.

Ref: https://godoc.org/golang.org/x/sys/windows/svc/mgr