### PR TITLE
Add support for LaunchAgents on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-    service, err := daemon.New("name", "description", daemon.GlobalDaemon)
+    service, err := daemon.New("name", "description", daemon.SystemDaemon)
     if err != nil {
         log.Fatal("Error: ", err)
     }
@@ -159,7 +159,7 @@ func init() {
 }
 
 func main() {
-    srv, err := daemon.New(name, description, daemon.GlobalDaemon, dependencies...)
+    srv, err := daemon.New(name, description, daemon.SystemDaemon, dependencies...)
     if err != nil {
         errlog.Println("Error: ", err)
         os.Exit(1)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-    service, err := daemon.New("name", "description")
+    service, err := daemon.New("name", "description", daemon.GlobalDaemon)
     if err != nil {
         log.Fatal("Error: ", err)
     }
@@ -159,7 +159,7 @@ func init() {
 }
 
 func main() {
-    srv, err := daemon.New(name, description, dependencies...)
+    srv, err := daemon.New(name, description, daemon.GlobalDaemon, dependencies...)
     if err != nil {
         errlog.Println("Error: ", err)
         os.Exit(1)

--- a/daemon.go
+++ b/daemon.go
@@ -5,10 +5,12 @@
 /*
 Package daemon v0.12.0 for use with Go (golang) services.
 
-Package daemon provides primitives for daemonization of golang services.
-This package is not provide implementation of user daemon,
-accordingly must have root rights to install/remove service.
-In the current implementation is only supported Linux and Mac Os X daemon.
+Package daemon provides primitives for daemonization of golang services. In the
+current implementation the only supported operating systems are macOS, FreeBSD,
+Linux and Windows. Also to note, for global daemons one must have root rights to
+install or remove the service. The only exception is macOS where there is an
+implementation of a user daemon that can installed or removed by the current
+user.
 
 Example:
 
@@ -137,7 +139,7 @@ Example:
 	}
 
 	func main() {
-		srv, err := daemon.New(name, description, dependencies...)
+		srv, err := daemon.New(name, description, daemon.GlobalDaemon, dependencies...)
 		if err != nil {
 			errlog.Println("Error: ", err)
 			os.Exit(1)

--- a/daemon.go
+++ b/daemon.go
@@ -199,11 +199,16 @@ type Executable interface {
 	Run()
 }
 
+// Kind is type of the daemon
+type Kind string
+
 // New - Create a new daemon
 //
 // name: name of the service
 //
 // description: any explanation, what is the service, its purpose
-func New(name, description string, dependencies ...string) (Daemon, error) {
-	return newDaemon(strings.Join(strings.Fields(name), "_"), description, dependencies)
+//
+// kind: what kind of daemon to create
+func New(name, description string, kind Kind, dependencies ...string) (Daemon, error) {
+	return newDaemon(strings.Join(strings.Fields(name), "_"), description, kind, dependencies)
 }

--- a/daemon_darwin.go
+++ b/daemon_darwin.go
@@ -22,23 +22,6 @@ type darwinRecord struct {
 	dependencies []string
 }
 
-const (
-	// UserAgent is a user daemon that runs as the currently logged in user and
-	// stores its property list in the user’s individual LaunchAgents directory.
-	// In other words, per-user agents provided by the user.
-	UserAgent Kind = "UserAgent"
-
-	// GlobalAgent is a user daemon that runs as the currently logged in user and
-	// stores its property list in the users' global LaunchAgents directory. In
-	// other words, per-user agents provided by the administrator.
-	GlobalAgent Kind = "GlobalAgent"
-
-	// GlobalDaemon is a system daemon that runs as the root user and stores its
-	// property list in the global LaunchDaemons directory. In other words,
-	// system-wide daemons provided by the administrator.
-	GlobalDaemon Kind = "GlobalDaemon"
-)
-
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 
 	return &darwinRecord{name, description, kind, dependencies}, nil

--- a/daemon_darwin.go
+++ b/daemon_darwin.go
@@ -17,12 +17,13 @@ import (
 type darwinRecord struct {
 	name         string
 	description  string
+	kind         Kind
 	dependencies []string
 }
 
-func newDaemon(name, description string, dependencies []string) (Daemon, error) {
+func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 
-	return &darwinRecord{name, description, dependencies}, nil
+	return &darwinRecord{name, description, kind, dependencies}, nil
 }
 
 // Standard service path for system daemons

--- a/daemon_darwin.go
+++ b/daemon_darwin.go
@@ -8,6 +8,7 @@ package daemon
 import (
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"text/template"
@@ -49,7 +50,8 @@ func (darwin *darwinRecord) servicePath() string {
 
 	switch darwin.kind {
 	case UserAgent:
-		path = "~/Library/LaunchAgents" + darwin.name + ".plist"
+		usr, _ := user.Current()
+		path = usr.HomeDir + "/Library/LaunchAgents/" + darwin.name + ".plist"
 	case GlobalAgent:
 		path = "/Library/LaunchAgents/" + darwin.name + ".plist"
 	case GlobalDaemon:

--- a/daemon_darwin.go
+++ b/daemon_darwin.go
@@ -21,6 +21,12 @@ type darwinRecord struct {
 	dependencies []string
 }
 
+const (
+	// GlobalDaemon is a user daemon that runs as the root user. In other words,
+	// system-wide daemons provided by the administrator.
+	GlobalDaemon Kind = "GlobalDaemon"
+)
+
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 
 	return &darwinRecord{name, description, kind, dependencies}, nil

--- a/daemon_freebsd.go
+++ b/daemon_freebsd.go
@@ -19,12 +19,6 @@ type bsdRecord struct {
 	dependencies []string
 }
 
-const (
-	// GlobalDaemon is a user daemon that runs as the root user. In other words,
-	// system-wide daemons provided by the administrator.
-	GlobalDaemon Kind = "GlobalDaemon"
-)
-
 // Standard service path for systemV daemons
 func (bsd *bsdRecord) servicePath() string {
 	return "/usr/local/etc/rc.d/" + bsd.name

--- a/daemon_freebsd.go
+++ b/daemon_freebsd.go
@@ -15,6 +15,7 @@ import (
 type bsdRecord struct {
 	name         string
 	description  string
+	kind         Kind
 	dependencies []string
 }
 
@@ -66,8 +67,8 @@ func (bsd *bsdRecord) getCmd(cmd string) string {
 }
 
 // Get the daemon properly
-func newDaemon(name, description string, dependencies []string) (Daemon, error) {
-	return &bsdRecord{name, description, dependencies}, nil
+func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
+	return &bsdRecord{name, description, kind, dependencies}, nil
 }
 
 func execPath() (name string, err error) {

--- a/daemon_freebsd.go
+++ b/daemon_freebsd.go
@@ -19,6 +19,12 @@ type bsdRecord struct {
 	dependencies []string
 }
 
+const (
+	// GlobalDaemon is a user daemon that runs as the root user. In other words,
+	// system-wide daemons provided by the administrator.
+	GlobalDaemon Kind = "GlobalDaemon"
+)
+
 // Standard service path for systemV daemons
 func (bsd *bsdRecord) servicePath() string {
 	return "/usr/local/etc/rc.d/" + bsd.name

--- a/daemon_linux.go
+++ b/daemon_linux.go
@@ -9,6 +9,12 @@ import (
 	"os"
 )
 
+const (
+	// GlobalDaemon is a user daemon that runs as the root user. In other words,
+	// system-wide daemons provided by the administrator.
+	GlobalDaemon Kind = "GlobalDaemon"
+)
+
 // Get the daemon properly
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 	// newer subsystem must be checked first

--- a/daemon_linux.go
+++ b/daemon_linux.go
@@ -10,15 +10,15 @@ import (
 )
 
 // Get the daemon properly
-func newDaemon(name, description string, dependencies []string) (Daemon, error) {
+func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 	// newer subsystem must be checked first
 	if _, err := os.Stat("/run/systemd/system"); err == nil {
-		return &systemDRecord{name, description, dependencies}, nil
+		return &systemDRecord{name, description, kind, dependencies}, nil
 	}
 	if _, err := os.Stat("/sbin/initctl"); err == nil {
-		return &upstartRecord{name, description, dependencies}, nil
+		return &upstartRecord{name, description, kind, dependencies}, nil
 	}
-	return &systemVRecord{name, description, dependencies}, nil
+	return &systemVRecord{name, description, kind, dependencies}, nil
 }
 
 // Get executable path

--- a/daemon_linux.go
+++ b/daemon_linux.go
@@ -9,12 +9,6 @@ import (
 	"os"
 )
 
-const (
-	// GlobalDaemon is a user daemon that runs as the root user. In other words,
-	// system-wide daemons provided by the administrator.
-	GlobalDaemon Kind = "GlobalDaemon"
-)
-
 // Get the daemon properly
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 	// newer subsystem must be checked first

--- a/daemon_linux_systemd.go
+++ b/daemon_linux_systemd.go
@@ -16,6 +16,7 @@ import (
 type systemDRecord struct {
 	name         string
 	description  string
+	kind         Kind
 	dependencies []string
 }
 

--- a/daemon_linux_systemv.go
+++ b/daemon_linux_systemv.go
@@ -16,6 +16,7 @@ import (
 type systemVRecord struct {
 	name         string
 	description  string
+	kind         Kind
 	dependencies []string
 }
 

--- a/daemon_linux_upstart.go
+++ b/daemon_linux_upstart.go
@@ -16,6 +16,7 @@ import (
 type upstartRecord struct {
 	name         string
 	description  string
+	kind         Kind
 	dependencies []string
 }
 

--- a/daemon_windows.go
+++ b/daemon_windows.go
@@ -28,6 +28,12 @@ type windowsRecord struct {
 	dependencies []string
 }
 
+const (
+	// GlobalDaemon is a user daemon that runs as the root user. In other words,
+	// system-wide daemons provided by the administrator.
+	GlobalDaemon Kind = "GlobalDaemon"
+)
+
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 
 	return &windowsRecord{name, description, kind, dependencies}, nil

--- a/daemon_windows.go
+++ b/daemon_windows.go
@@ -24,12 +24,13 @@ import (
 type windowsRecord struct {
 	name         string
 	description  string
+	kind         Kind
 	dependencies []string
 }
 
-func newDaemon(name, description string, dependencies []string) (Daemon, error) {
+func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 
-	return &windowsRecord{name, description, dependencies}, nil
+	return &windowsRecord{name, description, kind, dependencies}, nil
 }
 
 // Install the service

--- a/daemon_windows.go
+++ b/daemon_windows.go
@@ -28,12 +28,6 @@ type windowsRecord struct {
 	dependencies []string
 }
 
-const (
-	// GlobalDaemon is a user daemon that runs as the root user. In other words,
-	// system-wide daemons provided by the administrator.
-	GlobalDaemon Kind = "GlobalDaemon"
-)
-
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 
 	return &windowsRecord{name, description, kind, dependencies}, nil

--- a/examples/cron/cron_job.go
+++ b/examples/cron/cron_job.go
@@ -80,7 +80,7 @@ func init() {
 }
 
 func main() {
-	srv, err := daemon.New(name, description, daemon.GlobalDaemon)
+	srv, err := daemon.New(name, description, daemon.SystemDaemon)
 	if err != nil {
 		errlog.Println("Error: ", err)
 		os.Exit(1)

--- a/examples/cron/cron_job.go
+++ b/examples/cron/cron_job.go
@@ -80,7 +80,7 @@ func init() {
 }
 
 func main() {
-	srv, err := daemon.New(name, description)
+	srv, err := daemon.New(name, description, daemon.GlobalDaemon)
 	if err != nil {
 		errlog.Println("Error: ", err)
 		os.Exit(1)

--- a/examples/myservice.go
+++ b/examples/myservice.go
@@ -120,7 +120,7 @@ func init() {
 }
 
 func main() {
-	srv, err := daemon.New(name, description, dependencies...)
+	srv, err := daemon.New(name, description, daemon.GlobalDaemon, dependencies...)
 	if err != nil {
 		errlog.Println("Error: ", err)
 		os.Exit(1)

--- a/examples/myservice.go
+++ b/examples/myservice.go
@@ -120,7 +120,7 @@ func init() {
 }
 
 func main() {
-	srv, err := daemon.New(name, description, daemon.GlobalDaemon, dependencies...)
+	srv, err := daemon.New(name, description, daemon.SystemDaemon, dependencies...)
 	if err != nil {
 		errlog.Println("Error: ", err)
 		os.Exit(1)


### PR DESCRIPTION
Previously we supported global system daemons only across all supported operating systems. I'm adding support for user daemons _but only for macOS_. See distinction below:

* `UserAgent` is a user daemon that runs as the currently logged in user and stores its property list in the user’s individual LaunchAgents directory i.e. `~/Library/LaunchAgents/`. In other words, per-user agents provided by the user.
* `GlobalAgent` is a user daemon that runs as the currently logged in user and stores its property list in the users' global `LaunchAgents` directory i.e. `/Library/LaunchAgents`. In other words, per-user agents provided by the administrator.
* `GlobalDaemon` is a system daemon that runs as the root user and stores its property list in the global `LaunchDaemons` directory i.e. `/Library/LaunchDaemons`. In other words, system-wide daemons provided by the administrator.

Current approach allows the same to be done for other systems if need be. My main concern is that I couldn't find away to make these changes without changing the API i.e. `daemon.New` which is used for all operating systems.

For an easier review, follow the commits. Each commit is an idea and has an accompanying commit message just for extra context.

Closes https://github.com/takama/daemon/issues/89.