### PR TITLE
Fix systemd install failures

### DIFF
--- a/daemon_linux_systemd.go
+++ b/daemon_linux_systemd.go
@@ -73,7 +73,7 @@ func (linux *systemDRecord) Install(args ...string) (string, error) {
 	}
 	defer file.Close()
 
-	execPatch, err := executablePath(linux.name)
+	execPath, err := executablePath(linux.name)
 	if err != nil {
 		return installAction + failed, err
 	}
@@ -92,7 +92,7 @@ func (linux *systemDRecord) Install(args ...string) (string, error) {
 			path.Base(linux.name),
 			linux.description,
 			strings.Join(linux.dependencies, " "),
-			execPatch,
+			execPath,
 			strings.Join(args, " "),
 		},
 	); err != nil {

--- a/daemon_linux_systemd.go
+++ b/daemon_linux_systemd.go
@@ -7,6 +7,7 @@ package daemon
 import (
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strings"
 	"text/template"
@@ -85,9 +86,10 @@ func (linux *systemDRecord) Install(args ...string) (string, error) {
 	if err := templ.Execute(
 		file,
 		&struct {
-			Name, Description, Dependencies, Path, Args string
+			Name, BaseName, Description, Dependencies, Path, Args string
 		}{
 			linux.name,
+			path.Base(linux.name),
 			linux.description,
 			strings.Join(linux.dependencies, " "),
 			execPatch,
@@ -101,7 +103,7 @@ func (linux *systemDRecord) Install(args ...string) (string, error) {
 		return installAction + failed, err
 	}
 
-	if err := exec.Command("systemctl", "enable", linux.name+".service").Run(); err != nil {
+	if err := exec.Command("systemctl", "enable", path.Base(linux.name)+".service").Run(); err != nil {
 		return installAction + failed, err
 	}
 
@@ -217,8 +219,8 @@ Requires={{.Dependencies}}
 After={{.Dependencies}}
 
 [Service]
-PIDFile=/var/run/{{.Name}}.pid
-ExecStartPre=/bin/rm -f /var/run/{{.Name}}.pid
+PIDFile=/var/run/{{.BaseName}}.pid
+ExecStartPre=/bin/rm -f /var/run/{{.BaseName}}.pid
 ExecStart={{.Path}} {{.Args}}
 Restart=on-failure
 


### PR DESCRIPTION
In some cases where executable paths are not absolute (e.g. `./binary`) the systemd installation will fail.