### PR TITLE
Allow running daemons as non-root/administrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+vendor/

--- a/README.md
+++ b/README.md
@@ -213,6 +213,24 @@ WantedBy=multi-user.target
 
 See `examples/cron/cron_job.go`
 
+### SetUser and SetPassword
+If you want the system daemon to run under a normal user and not root, you can call `SetUser(username string)` to
+change the username the daemon will run as.
+
+If username isn't set specifically the default username will be set to `root` or `Administrator` depending on the OS. 
+
+#### Windows specific instructions
+If you are installing a service on Windows you will also need to set the user's password as well, using the
+`SetPassword(password string)` function. On Windows, you will also need to grant the user permissions to
+"Log on as a Service" permissions. This is done by opening the `Local Security Policy` tool, then navigating to
+`Local Policies` > `User Rights Assignment` > `Log on as a service` and add the username to this list.
+
+If the above permissions aren't granted, the service will install correctly, but will fail to start, as the user is
+unable to launch the daemon.
+
+For `SetUser` the username needs to be in the format of `DOMAIN\username`. If you are using a local system account,
+this can be written in shorthand notation, for example: `.\username`
+
 ## Contributors (unsorted)
 
 - [Sheile](https://github.com/Sheile)

--- a/daemon.go
+++ b/daemon.go
@@ -193,6 +193,12 @@ type Daemon interface {
 
 	// Run - run executable service
 	Run(e Executable) (string, error)
+
+	// SetUser - Sets the user the service will run as
+	SetUser(username string) error
+
+	// SetPassword - Sets the password for the user that will run the service. Only used for Windows services
+	SetPassword(password string) error
 }
 
 // Executable interface defines controlling methods of executable service

--- a/daemon_linux.go
+++ b/daemon_linux.go
@@ -13,12 +13,12 @@ import (
 func newDaemon(name, description string, kind Kind, dependencies []string) (Daemon, error) {
 	// newer subsystem must be checked first
 	if _, err := os.Stat("/run/systemd/system"); err == nil {
-		return &systemDRecord{name, description, kind, dependencies}, nil
+		return &systemDRecord{name, description, kind, "", dependencies}, nil
 	}
 	if _, err := os.Stat("/sbin/initctl"); err == nil {
-		return &upstartRecord{name, description, kind, dependencies}, nil
+		return &upstartRecord{name, description, kind, "", dependencies}, nil
 	}
-	return &systemVRecord{name, description, kind, dependencies}, nil
+	return &systemVRecord{name, description, kind, "", dependencies}, nil
 }
 
 // Get executable path

--- a/daemon_linux_systemd.go
+++ b/daemon_linux_systemd.go
@@ -17,6 +17,7 @@ type systemDRecord struct {
 	name         string
 	description  string
 	kind         Kind
+	username     string
 	dependencies []string
 }
 
@@ -77,6 +78,10 @@ func (linux *systemDRecord) Install(args ...string) (string, error) {
 		return installAction + failed, err
 	}
 
+	if linux.username == "" {
+		linux.username = "root"
+	}
+
 	templ, err := template.New("systemDConfig").Parse(systemDConfig)
 	if err != nil {
 		return installAction + failed, err
@@ -85,10 +90,11 @@ func (linux *systemDRecord) Install(args ...string) (string, error) {
 	if err := templ.Execute(
 		file,
 		&struct {
-			Name, Description, Dependencies, Path, Args string
+			Name, Description, Username, Dependencies, Path, Args string
 		}{
 			linux.name,
 			linux.description,
+			linux.username,
 			strings.Join(linux.dependencies, " "),
 			execPatch,
 			strings.Join(args, " "),
@@ -211,6 +217,17 @@ func (linux *systemDRecord) SetTemplate(tplStr string) error {
 	return nil
 }
 
+// SetUser - Sets the user the service will run as
+func (linux *systemDRecord) SetUser(username string) error {
+	linux.username = username
+	return nil
+}
+
+// SetPassword - Sets the password for the user that will run the service. Only used for macOS
+func (linux *systemDRecord) SetPassword(_ string) error {
+	return ErrUnsupportedSystem
+}
+
 var systemDConfig = `[Unit]
 Description={{.Description}}
 Requires={{.Dependencies}}
@@ -221,6 +238,7 @@ PIDFile=/var/run/{{.Name}}.pid
 ExecStartPre=/bin/rm -f /var/run/{{.Name}}.pid
 ExecStart={{.Path}} {{.Args}}
 Restart=on-failure
+User={{.Username}}
 
 [Install]
 WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/takama/daemon
+module github.com/bunjiboys/daemon
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bunjiboys/daemon
+module github.com/takama/daemon
 
 go 1.14
 

--- a/helper.go
+++ b/helper.go
@@ -38,6 +38,12 @@ var (
 
 	// ErrAlreadyStopped appears if try to stop already stopped service
 	ErrAlreadyStopped = errors.New("Service has already been stopped")
+
+	// ErrUserNameNotSupported appears if you try to set the service username on an unsupported service
+	ErrUserNameNotSupported = errors.New("Service kind does not support changing user")
+
+	// ErrUserPasswordNotProvided appears if you try and install a service on windows with a non-system account user
+	ErrUserPasswordNotProvided = errors.New("Password must be provided if using alternate user on Windows")
 )
 
 // ExecPath tries to get executable path


### PR DESCRIPTION
Added new methods SetUser and SetPassword to allow for running daemons as non-root user on all supported operating systems.

Also fixed a couple of typos and fixed a few OS specific methods to use the correct names, for example:
```
- func (linux *darwinRecord) GetTemplate() string {
+ func (darwin *darwinRecord) GetTemplate() string {
```

This has been tested on all supported OS types.